### PR TITLE
Remove vendored try_call, use process.call instead

### DIFF
--- a/src/chrobot.gleam
+++ b/src/chrobot.gleam
@@ -739,7 +739,7 @@ pub fn await_load_event(browser, page: Page) {
   use _ <- result.try(page.enable(page_caller(page)))
 
   // // Wait for the load event to fire
-  chrome.listen_once(browser, "Page.loadEventFired", page.time_out)
+  Ok(chrome.listen_once(browser, "Page.loadEventFired", page.time_out))
 }
 
 /// Quit the browser (alias for [`chrome.quit`](/chrobot/chrome.html#quit))

--- a/src/chrobot.gleam
+++ b/src/chrobot.gleam
@@ -780,8 +780,7 @@ fn do_poll(
   // available time before current polling attempt
   let available_time = deadline - utils.get_time_ms()
 
-  // We guard against negative time because it would cause a panic in try_await
-  // but realistically this should never happen anyways
+  // We guard against negative time as it means the deadline has already passed
   use <- bool.guard(available_time < 0, Error(chrome.ChromeAgentTimeout))
 
   let subject = process.new_subject()

--- a/src/chrobot/chrome.gleam
+++ b/src/chrobot/chrome.gleam
@@ -89,11 +89,8 @@ pub type LaunchError {
 pub type RequestError {
   // Port communication failed
   PortError
-  /// OTP actor timeout
+  /// Polling timeout — the polling deadline was exceeded
   ChromeAgentTimeout
-
-  /// OTP actor down
-  ChromeAgentDown
 
   /// The ProtocolError variant is used by `/protocol` domains
   /// to return a homogeneous error type for all requests.
@@ -261,10 +258,7 @@ pub fn launch_with_env() -> Result(Subject(Message), LaunchError) {
 /// Quit the browser and shut down the actor.
 /// This function will attempt graceful shutdown, if the browser does not respond in time,
 /// it will also send a kill signal to the actor to force it to shut down.
-///
-/// ## Panics
-///
-/// This function may panic if the browser actor is down or does not respond in time.
+/// Be aware that this function may panic if the browser actor is down or does not respond in time.
 pub fn quit(browser: Subject(Message)) -> Nil {
   // set a deadline for a kill signal to be sent if the browser does not respond in time
   let _ = process.send_after(browser, default_timeout * 2, Kill)
@@ -272,11 +266,8 @@ pub fn quit(browser: Subject(Message)) -> Nil {
   process.call(browser, waiting: default_timeout, sending: Shutdown)
 }
 
-/// Issue a protocol call to the browser and expect a response
-///
-/// ## Panics
-///
-/// This function may panic if the browser actor is down or does not respond in time.
+/// Issue a protocol call to the browser and expect a response.
+/// Be aware that this function may panic if the browser actor is down or does not respond in time.
 pub fn call(
   browser: Subject(Message),
   method: String,
@@ -294,10 +285,7 @@ pub fn call(
 
 /// A blocking call that waits for a specified event to arrive once,
 /// and then resolves, removing the event listener.
-///
-/// ## Panics
-///
-/// This function may panic if the event does not arrive before the timeout.
+/// Be aware that this function may panic if the event does not arrive before the timeout.
 pub fn listen_once(
   browser: Subject(Message),
   method: String,

--- a/src/chrobot/chrome.gleam
+++ b/src/chrobot/chrome.gleam
@@ -95,7 +95,7 @@ pub type RequestError {
   /// OTP actor down
   ChromeAgentDown
 
-  /// The ProtocolError variant is used by `/protocol` domains 
+  /// The ProtocolError variant is used by `/protocol` domains
   /// to return a homogeneous error type for all requests.
   ProtocolError
 
@@ -258,19 +258,25 @@ pub fn launch_with_env() -> Result(Subject(Message), LaunchError) {
   }
 }
 
-/// Quit the browser and shut down the actor.  
+/// Quit the browser and shut down the actor.
 /// This function will attempt graceful shutdown, if the browser does not respond in time,
 /// it will also send a kill signal to the actor to force it to shut down.
-/// The result typing reflects the success of graceful shutdown.
-pub fn quit(browser: Subject(Message)) -> Result(Nil, RequestError) {
+///
+/// ## Panics
+///
+/// This function may panic if the browser actor is down or does not respond in time.
+pub fn quit(browser: Subject(Message)) -> Nil {
   // set a deadline for a kill signal to be sent if the browser does not respond in time
   let _ = process.send_after(browser, default_timeout * 2, Kill)
   // invoke graceful shutdown of the browser
-  utils.try_call(browser, Shutdown, default_timeout)
-  |> result.map_error(map_call_error)
+  process.call(browser, waiting: default_timeout, sending: Shutdown)
 }
 
 /// Issue a protocol call to the browser and expect a response
+///
+/// ## Panics
+///
+/// This function may panic if the browser actor is down or does not respond in time.
 pub fn call(
   browser: Subject(Message),
   method: String,
@@ -278,30 +284,35 @@ pub fn call(
   session_id: Option(String),
   time_out,
 ) -> Result(d.Dynamic, RequestError) {
-  case utils.try_call(browser, Call(_, method, params, session_id), time_out) {
-    Ok(nested_result) -> nested_result
-    Error(err) -> Error(map_call_error(err))
-  }
+  process.call(browser, waiting: time_out, sending: Call(
+    _,
+    method,
+    params,
+    session_id,
+  ))
 }
 
 /// A blocking call that waits for a specified event to arrive once,
 /// and then resolves, removing the event listener.
+///
+/// ## Panics
+///
+/// This function may panic if the event does not arrive before the timeout.
 pub fn listen_once(
   browser: Subject(Message),
   method: String,
   time_out,
-) -> Result(d.Dynamic, RequestError) {
+) -> d.Dynamic {
   let event_subject = process.new_subject()
-  let call_response =
-    utils.try_call_with_subject(
-      browser,
-      AddListener(_, method),
-      event_subject,
-      time_out,
-    )
+  process.send(browser, AddListener(event_subject, method))
+  let result =
+    process.new_selector()
+    |> process.select(event_subject)
+    |> process.selector_receive(within: time_out)
   process.send(browser, RemoveListener(event_subject))
-  call_response
-  |> result.map_error(map_call_error)
+  let assert Ok(event_data) = result
+    as "listen_once timed out waiting for event"
+  event_data
 }
 
 /// Add an event listener
@@ -1117,13 +1128,6 @@ fn log_debug(state: BrowserState, callback: fn() -> String) {
       )
     }
     _ -> Nil
-  }
-}
-
-fn map_call_error(err: utils.CallError) -> RequestError {
-  case err {
-    utils.CallTimeout -> ChromeAgentTimeout
-    utils.CalleeDown(..) -> ChromeAgentDown
   }
 }
 

--- a/src/chrobot/internal/utils.gleam
+++ b/src/chrobot/internal/utils.gleam
@@ -1,5 +1,4 @@
 import envoy
-import gleam/erlang/process.{type Subject} as p
 import gleam/io
 import gleam/json
 import gleam/list
@@ -7,12 +6,6 @@ import gleam/option.{type Option, None, Some}
 import gleam/string
 import gleam_community/ansi
 import spinner
-
-/// Errors that can occur when calling a process
-pub type CallError {
-  CallTimeout
-  CalleeDown(reason: p.ExitReason)
-}
 
 /// Very very naive but should be fine
 fn term_supports_color() -> Bool {
@@ -170,57 +163,6 @@ pub fn show_cmd(content: String) {
       io.println("\n $ " <> content <> "\n")
     }
   }
-}
-
-pub fn try_call_with_subject(
-  subject: Subject(request),
-  make_request: fn(Subject(response)) -> request,
-  reply_subject: Subject(response),
-  within timeout: Int,
-) -> Result(response, CallError) {
-  // Get the owner PID of the subject - if it fails, the process is down
-  case p.subject_owner(subject) {
-    Error(Nil) -> Error(CalleeDown(reason: p.Normal))
-    Ok(owner_pid) -> {
-      // Monitor the callee process so we can tell if it goes down (meaning we
-      // won't get a reply)
-      let monitor = p.monitor(owner_pid)
-
-      // Send the request to the process over the channel
-      p.send(subject, make_request(reply_subject))
-
-      // Await a reply or handle failure modes (timeout, process down, etc)
-      let result =
-        p.new_selector()
-        |> p.select_map(reply_subject, Ok)
-        |> p.select_specific_monitor(monitor, fn(down: p.Down) {
-          case down {
-            p.ProcessDown(reason: reason, ..) -> Error(CalleeDown(reason:))
-            p.PortDown(reason: reason, ..) -> Error(CalleeDown(reason:))
-          }
-        })
-        |> p.selector_receive(within: timeout)
-
-      // Demonitor the process and close the channels as we're done
-      p.demonitor_process(monitor)
-
-      // Prepare an appropriate error (if present) for the caller
-      case result {
-        Error(Nil) -> Error(CallTimeout)
-        Ok(res) -> res
-      }
-    }
-  }
-}
-
-/// A version of process.call that returns a Result instead of panicking
-pub fn try_call(
-  subject: Subject(request),
-  make_request: fn(Subject(response)) -> request,
-  within timeout: Int,
-) -> Result(response, CallError) {
-  let reply_subject = p.new_subject()
-  try_call_with_subject(subject, make_request, reply_subject, timeout)
 }
 
 /// (Taken from the old gleam_stlib where it was `list.pop_map`)

--- a/test/chrome_test.gleam
+++ b/test/chrome_test.gleam
@@ -394,7 +394,7 @@ pub fn launch_with_config_test() {
     )
   let browser_subject = should.be_ok(chrome.launch_with_config(config))
   should.be_ok(chrome.get_version(browser_subject))
-  should.be_ok(chrome.quit(browser_subject))
+  chrome.quit(browser_subject)
 }
 
 // Ensure the call function correctly handles errors sent by the browser
@@ -435,7 +435,7 @@ pub fn handle_protocol_error_test() {
     Ok(_) -> panic as "didn't receive error from call with invalid payload"
     _ -> panic as "didn't receive correct error from call with invalid payload"
   }
-  should.be_ok(chrome.quit(browser_subject))
+  chrome.quit(browser_subject)
 }
 
 pub fn handle_protocol_error_2_test() {
@@ -463,7 +463,7 @@ pub fn handle_protocol_error_2_test() {
     _ -> panic as "didn't receive correct error from call with invalid method"
   }
 
-  should.be_ok(chrome.quit(browser_subject))
+  chrome.quit(browser_subject)
 }
 
 pub fn process_port_message_test() {


### PR DESCRIPTION
Replaced the vendored `try_call` with `process.call` directly in the chrome actor's `quit`, `call`, and `listen_once` functions, as discussed in #28.

`ChromeAgentDown` had no producer left after the change so I dropped it. Also updated the `ChromeAgentTimeout` comment since it's only used in polling now, not for actual actor timeouts  those just panic. Fixed a stale `try_await` reference in `do_poll` while I was at it.

The code gets simpler since we no longer need `CallError`, `map_call_error`, or the vendored `try_call`/`try_call_with_subject` in the hot path.

Closes #28